### PR TITLE
Storing/accessing images from Airtable

### DIFF
--- a/lib/airtable.ts
+++ b/lib/airtable.ts
@@ -12,7 +12,7 @@ export const base = Airtable.base(process.env.AIRTABLE_BASE_ID ?? "");
  * @param attachmentArr Array of objects, or undefined.
  * @returns String photo url.
  */
-export function getPhotoUrlFromAttachmentObj(attachmentArr: Array<any> | undefined) {
+export function getPhotoUrlFromAttachmentObj(attachmentArr: Array<any> | undefined): string | null {
   // check if array is undefined
   if (attachmentArr === undefined) {
     return null;

--- a/lib/airtable.ts
+++ b/lib/airtable.ts
@@ -6,3 +6,27 @@ Airtable.configure({
 });
 
 export const base = Airtable.base(process.env.AIRTABLE_BASE_ID ?? "");
+
+/**
+ * Returns the photo url from Airtable's attachment array.
+ * @param attachmentArr Array of objects, or undefined.
+ * @returns String photo url.
+ */
+export function getPhotoUrlFromAttachmentObj(attachmentArr: Array<any> | undefined) {
+  // check if array is undefined
+  if (attachmentArr === undefined) {
+    return null;
+  }
+
+  // if not undefined, return the first attachement that is an image
+  let photoUrl = "";
+  if (Array.isArray(attachmentArr)) {
+    for (const currImg of attachmentArr) {
+      if (currImg.type.includes("image")) {
+        photoUrl = currImg.url;
+      }
+    }
+  }
+
+  return photoUrl;
+};

--- a/lib/people.ts
+++ b/lib/people.ts
@@ -1,4 +1,4 @@
-import { base } from "./airtable";
+import { base, getPhotoUrlFromAttachmentObj } from "./airtable";
 
 export type Person = {
   id: string;
@@ -30,7 +30,7 @@ export async function fetchPeople(): Promise<Person[]> {
                 "Undergraduate Student Researcher",
               status: (record.get("status") as string) ?? "Active",
               bio: (record.get("bio") as string) ?? "",
-              photoUrl: (record.get("photo_url") as string) ?? null,
+              photoUrl: getPhotoUrlFromAttachmentObj(record.get("photo_url") as Array<any>),
             });
           });
 

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -1,4 +1,4 @@
-import { base } from "./airtable";
+import { base, getPhotoUrlFromAttachmentObj } from "./airtable";
 import { Person, fetchPeople, sortPeople } from "./people";
 
 // TODO: this can be optimized for data usage by only including needed info for Person
@@ -106,7 +106,7 @@ export async function fetchProjectImages(
       // get all additional images for the project
       const explainerImages: ProjectImages["explainerImages"] = [];
       [1, 2, 3, 4, 5].map((i) => {
-        const imageUrl = record.get(`image_${i}_url`) as string;
+        const imageUrl = getPhotoUrlFromAttachmentObj(record.get(`image_${i}_url`) as Array<any>);
         const description = record.get(`image_${i}_description`) as string;
 
         if (imageUrl && description) {
@@ -118,7 +118,7 @@ export async function fetchProjectImages(
       });
 
       resolve({
-        bannerImageUrl: (record.get("banner_image_url") as string) ?? null,
+        bannerImageUrl: getPhotoUrlFromAttachmentObj(record.get("banner_image_url") as Array<any>),
         explainerImages,
       });
     });

--- a/lib/sig.ts
+++ b/lib/sig.ts
@@ -1,4 +1,4 @@
-import { base } from "./airtable";
+import { base, getPhotoUrlFromAttachmentObj } from "./airtable";
 import { Person, fetchPeople, sortPeople } from "./people";
 import { Project, getProject } from "./project";
 
@@ -69,7 +69,7 @@ export async function fetchSigs(): Promise<SIG[]> {
               name: (record.get("name") as string) ?? "",
               description: (record.get("description") as string) ?? "",
               bannerImageUrl:
-                (record.get("banner_image_url") as string) ?? null,
+                getPhotoUrlFromAttachmentObj(record.get("banner_image_url") as Array<any>),
               members,
               projects,
             });

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,6 @@
 module.exports = {
   reactStrictMode: true,
   images: {
-    domains: ["delta-lab.nyc3.cdn.digitaloceanspaces.com"],
+    domains: ["delta-lab.nyc3.cdn.digitaloceanspaces.com", "dl.airtable.com"],
   },
 };


### PR DESCRIPTION
This PR changes how we store and retrieve images for the DTR website to use AIrtable's in-base storage, rather than using our bucket storage. This change will make it easier for members of DTR to add/edit images. Initially, we used our bucket storage because of storage concerns, but given the data that we have now it should be ok for many years.

closes #48.