### PR TITLE
Optimizing amount of data sent to client

### DIFF
--- a/components/people/TeamMembers.tsx
+++ b/components/people/TeamMembers.tsx
@@ -1,8 +1,8 @@
-import { Person } from "../../lib/people";
+import { PartialPerson, Person } from "../../lib/people";
 
 interface TeamMemberProps {
   groupId: string;
-  members: Person[];
+  members: PartialPerson[];
 }
 
 export default function TeamMembers({
@@ -48,7 +48,7 @@ export default function TeamMembers({
 }
 
 interface MembersForRoleProps {
-  members: Person[];
+  members: PartialPerson[];
 }
 
 function MembersForRole({ members }: MembersForRoleProps): JSX.Element {

--- a/lib/airtable.ts
+++ b/lib/airtable.ts
@@ -12,7 +12,7 @@ export const base = Airtable.base(process.env.AIRTABLE_BASE_ID ?? "");
  * @param attachmentArr Array of objects, or undefined.
  * @returns String photo url.
  */
-export function getPhotoUrlFromAttachmentObj(attachmentArr: Array<any> | undefined) {
+export function getPhotoUrlFromAttachmentObj(attachmentArr: Array<any> | undefined): string | null {
   // check if array is undefined
   if (attachmentArr === undefined) {
     return null;

--- a/lib/airtable.ts
+++ b/lib/airtable.ts
@@ -6,3 +6,27 @@ Airtable.configure({
 });
 
 export const base = Airtable.base(process.env.AIRTABLE_BASE_ID ?? "");
+
+/**
+ * Returns the photo url from Airtable's attachment array.
+ * @param attachmentArr Array of objects, or undefined.
+ * @returns String photo url.
+ */
+export function getPhotoUrlFromAttachmentObj(attachmentArr: Array<any> | undefined) {
+  // check if array is undefined
+  if (attachmentArr === undefined) {
+    return null;
+  }
+
+  // if not undefined, return the first attachement that is an image
+  let photoUrl = "";
+  if (Array.isArray(attachmentArr)) {
+    for (const currImg of attachmentArr) {
+      if (currImg.type.includes("image")) {
+        photoUrl = currImg.url;
+      }
+    }
+  }
+
+  return photoUrl;
+};

--- a/lib/people.ts
+++ b/lib/people.ts
@@ -10,6 +10,14 @@ export type Person = {
   photoUrl: string | null;
 };
 
+export type PartialPerson = {
+  id: string;
+  name: string;
+  role: string;
+  status: string;
+  photoUrl: string | null;
+};
+
 export async function fetchPeople(): Promise<Person[]> {
   return new Promise((resolve, reject) => {
     const results: Person[] = [];

--- a/lib/people.ts
+++ b/lib/people.ts
@@ -1,4 +1,4 @@
-import { base } from "./airtable";
+import { base, getPhotoUrlFromAttachmentObj } from "./airtable";
 
 export type Person = {
   id: string;
@@ -30,7 +30,7 @@ export async function fetchPeople(): Promise<Person[]> {
                 "Undergraduate Student Researcher",
               status: (record.get("status") as string) ?? "Active",
               bio: (record.get("bio") as string) ?? "",
-              photoUrl: (record.get("photo_url") as string) ?? null,
+              photoUrl: getPhotoUrlFromAttachmentObj(record.get("photo_url") as Array<any>),
             });
           });
 

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -1,4 +1,4 @@
-import { base } from "./airtable";
+import { base, getPhotoUrlFromAttachmentObj } from "./airtable";
 import { Person, fetchPeople, sortPeople } from "./people";
 
 // TODO: this can be optimized for data usage by only including needed info for Person
@@ -106,7 +106,7 @@ export async function fetchProjectImages(
       // get all additional images for the project
       const explainerImages: ProjectImages["explainerImages"] = [];
       [1, 2, 3, 4, 5].map((i) => {
-        const imageUrl = record.get(`image_${i}_url`) as string;
+        const imageUrl = getPhotoUrlFromAttachmentObj(record.get(`image_${i}_url`) as Array<any>);
         const description = record.get(`image_${i}_description`) as string;
 
         if (imageUrl && description) {
@@ -118,7 +118,7 @@ export async function fetchProjectImages(
       });
 
       resolve({
-        bannerImageUrl: (record.get("banner_image_url") as string) ?? null,
+        bannerImageUrl: getPhotoUrlFromAttachmentObj(record.get("banner_image_url") as Array<any>),
         explainerImages,
       });
     });

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -1,8 +1,6 @@
 import { base, getPhotoUrlFromAttachmentObj } from "./airtable";
-import { Person, fetchPeople, sortPeople } from "./people";
+import { Person, PartialPerson, fetchPeople, sortPeople } from "./people";
 
-// TODO: this can be optimized for data usage by only including needed info for Person
-// Needed Person data for Project display: id, name, role, status
 export type Project = {
   id: string;
   name: string;
@@ -10,9 +8,16 @@ export type Project = {
   status: string;
   demo_video: string | null;
   sprint_video: string | null;
-  members: Person[];
+  members: PartialPerson[];
   images: ProjectImages;
   publications: ProjectPublication[];
+};
+
+export type PartialProject = {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
 };
 
 export async function getProject(
@@ -40,20 +45,31 @@ export async function getProject(
           return fetchedMembers.includes(person.name);
         })
       );
+      const partialPeopleOnProj: PartialPerson[] = peopleOnProj.map(
+        (person) => {
+          return {
+            id: person.id,
+            name: person.name,
+            role: person.role,
+            status: person.status,
+            photoUrl: person.photoUrl,
+          }
+        }
+      );
 
-      const partialProject = {
+      const partialProjectInfo = {
         id: record.id as string,
         name: (record.get("name") as string) ?? "",
         description: (record.get("description") as string) ?? "",
         status: (record.get("status") as string) ?? "Active",
         demo_video: (record.get("demo_video") as string) ?? null,
         sprint_video: (record.get("sprint_video") as string) ?? null,
-        members: peopleOnProj,
+        members: partialPeopleOnProj,
       };
 
       if (!getAllData) {
         resolve({
-          ...partialProject,
+          ...partialProjectInfo,
           images: {
             bannerImageUrl: null,
             explainerImages: [],
@@ -73,7 +89,7 @@ export async function getProject(
       );
 
       resolve({
-        ...partialProject,
+        ...partialProjectInfo,
         images,
         publications,
       });

--- a/lib/sig.ts
+++ b/lib/sig.ts
@@ -1,17 +1,14 @@
 import { base, getPhotoUrlFromAttachmentObj } from "./airtable";
-import { Person, fetchPeople, sortPeople } from "./people";
-import { Project, getProject } from "./project";
+import { Person, PartialPerson, fetchPeople, sortPeople } from "./people";
+import { Project, PartialProject, getProject } from "./project";
 
-// TODO: this can be optimized for data usage by only including needed info for Person/Project
-// Needed Person data for SIG display: id, name, role, status
-// Needed Project data for SIG display: id, name, description, status
 export type SIG = {
   id: string;
   name: string;
   description: string;
   bannerImageUrl: string | null;
-  members: Person[];
-  projects: Project[];
+  members: PartialPerson[];
+  projects: PartialProject[];
 };
 
 export async function fetchSigs(): Promise<SIG[]> {
@@ -33,6 +30,24 @@ export async function fetchSigs(): Promise<SIG[]> {
             const projects: Project[] = await Promise.all(
               projectIds.map((projectId) => getProject(projectId))
             );
+
+            const partialProjects: PartialProject[] = projects.map((project) => {
+              // pre-trim text not needed to be transferred over the wire since text can be long
+              // have at most 150 chars, removing partial words if they are cut
+              // from: https://stackoverflow.com/a/5454303
+              let maxCharLen = 150;
+              let preTrimmedDescription = (project.description?.substring(0, maxCharLen) ?? "");
+              preTrimmedDescription = preTrimmedDescription.substring(0,
+                Math.min(preTrimmedDescription.length, preTrimmedDescription.lastIndexOf(" ")));
+              preTrimmedDescription += (project.description?.length ?? 0) > maxCharLen ? "..." : "";
+
+              return {
+                id: project.id,
+                name: project.name,
+                description: preTrimmedDescription,
+                status: project.status
+              };
+            });
 
             // get students on each proj, SIG faculty mentors, and SIG heads
             const fetchedMembers: string[] =
@@ -63,6 +78,16 @@ export async function fetchSigs(): Promise<SIG[]> {
               ),
             ];
 
+            const partialMembers: PartialPerson[] = members.map((person) => {
+              return {
+                id: person.id,
+                name: person.name,
+                role: person.role,
+                status: person.status,
+                photoUrl: person.photoUrl,
+              }
+            });
+
             // add results
             results.push({
               id: record.id,
@@ -70,8 +95,8 @@ export async function fetchSigs(): Promise<SIG[]> {
               description: (record.get("description") as string) ?? "",
               bannerImageUrl:
                 getPhotoUrlFromAttachmentObj(record.get("banner_image_url") as Array<any>),
-              members,
-              projects,
+              members: partialMembers,
+              projects: partialProjects,
             });
           }
 

--- a/lib/sig.ts
+++ b/lib/sig.ts
@@ -1,4 +1,4 @@
-import { base } from "./airtable";
+import { base, getPhotoUrlFromAttachmentObj } from "./airtable";
 import { Person, fetchPeople, sortPeople } from "./people";
 import { Project, getProject } from "./project";
 
@@ -69,7 +69,7 @@ export async function fetchSigs(): Promise<SIG[]> {
               name: (record.get("name") as string) ?? "",
               description: (record.get("description") as string) ?? "",
               bannerImageUrl:
-                (record.get("banner_image_url") as string) ?? null,
+                getPhotoUrlFromAttachmentObj(record.get("banner_image_url") as Array<any>),
               members,
               projects,
             });

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,6 @@
 module.exports = {
   reactStrictMode: true,
   images: {
-    domains: ["delta-lab.nyc3.cdn.digitaloceanspaces.com"],
+    domains: ["delta-lab.nyc3.cdn.digitaloceanspaces.com", "dl.airtable.com"],
   },
 };

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -50,8 +50,7 @@ export default function Projects({ sigs }: ProjectProps): JSX.Element {
                     </Link>
 
                     <ReactMarkdown linkTarget="_blank" className="prose mt-2">
-                      {(project.description?.substring(0, 140) ?? "") +
-                        ((project.description?.length ?? 0) > 140 ? "..." : "")}
+                      {project.description}
                     </ReactMarkdown>
                   </div>
                 ))}


### PR DESCRIPTION
This PR aims to reduce the amount of data sent from the server to the client after being pulled from Airtable. To do this, this PR implements a `PartialPerson` and `PartialProject` type that only includes the data that `sig.ts` and `project.ts` need to display SIGs on the `/project` page and individual projects on each `project//[id]` page. 

Note that should should be merged in after PR #49.

Closes #50 