### PR TITLE
fix(deploy): copy pnpm workspace config into docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:lts-alpine AS base
 # Stage 1: deps
 FROM base AS deps
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable pnpm && pnpm install --frozen-lockfile
 
 # Stage 2: build


### PR DESCRIPTION
### 📌 Description

DigitalOcean Docker builds run pnpm install before the full repository is copied. The deps stage only copied package.json and pnpm-lock.yaml, so pnpm could not read pnpm-workspace.yaml and rejected ts-airtable@0.4.0 under the minimumReleaseAge policy.

### 🛠 Bug Fixes

- [x] Copy pnpm-workspace.yaml into the Docker deps stage before pnpm install.

### ✅ Checklist

- [x] Bug has been reproduced from the DigitalOcean build log.
- [x] Fix does not introduce new issues.

### 📝 Steps to Reproduce (before fix)

Run the Docker deps stage with pnpm install --frozen-lockfile after copying only package.json and pnpm-lock.yaml. pnpm cannot see the ts-airtable release-age exception from pnpm-workspace.yaml and fails the policy check.

### 💬 Additional Notes

Local checks: CI=true pnpm install --frozen-lockfile; pnpm lint.