### PR TITLE
feat(letters): automate annual letter submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/annual_letter.yml
+++ b/.github/ISSUE_TEMPLATE/annual_letter.yml
@@ -6,10 +6,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form to submit a new DTR annual letter.
+        Use this form to submit a new DTR annual letter. Maintainer submissions automatically open or update a PR.
 
-        After the issue is reviewed, a maintainer should comment `/annual-letter create-pr`.
-        That command runs the automation that opens a PR updating `public/letters/` and `src/lib/annual-letters.ts`.
+        The automation updates `public/letters/` and `src/lib/annual-letters.ts`.
 
   - type: input
     id: year
@@ -66,5 +65,5 @@ body:
           required: true
         - label: The table of contents page numbers have been checked against the PDF.
           required: true
-        - label: I understand a maintainer must comment `/annual-letter create-pr` to create the PR.
+        - label: I understand maintainer submissions automatically open a PR.
           required: true

--- a/.github/ISSUE_TEMPLATE/annual_letter.yml
+++ b/.github/ISSUE_TEMPLATE/annual_letter.yml
@@ -1,0 +1,70 @@
+name: Annual Letter
+description: Submit a new DTR annual letter PDF and table of contents
+title: '[Annual Letter]: '
+labels: [content-updating]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to submit a new DTR annual letter.
+
+        After the issue is reviewed, a maintainer should comment `/annual-letter create-pr`.
+        That command runs the automation that opens a PR updating `public/letters/` and `src/lib/annual-letters.ts`.
+
+  - type: input
+    id: year
+    attributes:
+      label: Annual letter year
+      description: The year shown in the site UI.
+      placeholder: '2026'
+    validations:
+      required: true
+
+  - type: input
+    id: publication_date
+    attributes:
+      label: Publication date
+      description: Use YYYY-MM-DD.
+      placeholder: 2026-08-01
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Optional short RSS description. Leave blank to match the existing annual letters.
+      placeholder: Optional summary for RSS readers.
+
+  - type: textarea
+    id: pdf
+    attributes:
+      label: PDF upload or URL
+      description: Drag the PDF into this field, or paste a direct URL to the PDF.
+      placeholder: Drag 2026-dtr-letter.pdf here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: table_of_contents
+    attributes:
+      label: Table of contents
+      description: One section per line, formatted as `section name | page`.
+      placeholder: |
+        welcome | 1
+        celebrating success | 2
+        an invitation | 24
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Checklist
+      options:
+        - label: The uploaded file is the final PDF.
+          required: true
+        - label: The table of contents page numbers have been checked against the PDF.
+          required: true
+        - label: I understand a maintainer must comment `/annual-letter create-pr` to create the PR.
+          required: true

--- a/.github/workflows/annual-letter-issue.yml
+++ b/.github/workflows/annual-letter-issue.yml
@@ -24,7 +24,6 @@ jobs:
       || (
         github.event.issue.pull_request == null
         && startsWith(github.event.issue.title, '[Annual Letter]:')
-        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -42,29 +41,64 @@ jobs:
       - name: 🛠️ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: lts/*
 
-      - name: 🔎 Resolve issue payload
+      - name: 🔎 Validate and resolve issue payload
+        id: issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            gh issue view "$ISSUE_NUMBER" --json body,number,title > annual-letter-issue.json
-            echo "ANNUAL_LETTER_ISSUE_PATH=annual-letter-issue.json" >> "$GITHUB_ENV"
-          else
-            echo "ANNUAL_LETTER_ISSUE_PATH=$GITHUB_EVENT_PATH" >> "$GITHUB_ENV"
+          skip_issue_event() {
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::$1"
+          }
+
+          reject() {
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "::error::$1"
+              exit 1
+            fi
+
+            skip_issue_event "$1"
+            exit 0
+          }
+
+          permission="$(gh api "repos/${REPOSITORY}/collaborators/${TRIGGERING_ACTOR}/permission" --jq '.permission' 2>/dev/null || echo none)"
+          case "$permission" in
+            admin|maintain) ;;
+            *) reject "Annual letter automation requires admin or maintain repository permission. ${TRIGGERING_ACTOR} has ${permission}." ;;
+          esac
+
+          gh issue view "$ISSUE_NUMBER" --json body,number,title,labels > annual-letter-issue.json
+
+          title="$(node -e "const fs=require('node:fs'); const issue=JSON.parse(fs.readFileSync('annual-letter-issue.json','utf8')); console.log(issue.title || '')")"
+          if [ "${title#\[Annual Letter\]:}" = "$title" ]; then
+            reject "Issue #${ISSUE_NUMBER} is not an Annual Letter issue."
           fi
 
+          if ! node -e "const fs=require('node:fs'); const issue=JSON.parse(fs.readFileSync('annual-letter-issue.json','utf8')); process.exit(issue.labels?.some(label => label.name === 'content-updating') ? 0 : 1)"; then
+            reject "Issue #${ISSUE_NUMBER} is missing the content-updating label."
+          fi
+
+          echo "ANNUAL_LETTER_ISSUE_PATH=annual-letter-issue.json" >> "$GITHUB_ENV"
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
       - name: 📝 Generate annual letter changes
+        if: steps.issue.outputs.should_run == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/annual-letter-from-issue.ts
 
       - name: 🔎 Show generated changes
+        if: steps.issue.outputs.should_run == 'true'
         run: git diff --stat
 
       - name: 🌿 Commit and open PR
+        if: steps.issue.outputs.should_run == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}

--- a/.github/workflows/annual-letter-issue.yml
+++ b/.github/workflows/annual-letter-issue.yml
@@ -1,9 +1,10 @@
 name: 📬 Annual Letter Issue
 
 on:
-  issue_comment:
+  issues:
     types:
-      - created
+      - opened
+      - edited
   workflow_dispatch:
     inputs:
       issue_number:
@@ -22,8 +23,8 @@ jobs:
       github.event_name == 'workflow_dispatch'
       || (
         github.event.issue.pull_request == null
-        && startsWith(github.event.comment.body, '/annual-letter create-pr')
-        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        && startsWith(github.event.issue.title, '[Annual Letter]:')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -37,6 +38,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+
+      - name: 🛠️ Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
 
       - name: 🔎 Resolve issue payload
         env:
@@ -53,7 +59,7 @@ jobs:
       - name: 📝 Generate annual letter changes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/annual-letter-from-issue.mjs
+        run: node scripts/annual-letter-from-issue.ts
 
       - name: 🔎 Show generated changes
         run: git diff --stat
@@ -112,4 +118,4 @@ jobs:
               --body-file "$body_file")"
           fi
 
-          gh issue comment "$ISSUE_NUMBER" --body "Annual letter PR created: ${pr_url}"
+          gh issue comment "$ISSUE_NUMBER" --body "Annual letter PR ready: ${pr_url}"

--- a/.github/workflows/annual-letter-issue.yml
+++ b/.github/workflows/annual-letter-issue.yml
@@ -1,0 +1,115 @@
+name: 📬 Annual Letter Issue
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number created from the Annual Letter template
+        required: true
+        type: number
+
+concurrency:
+  group: annual-letter-issue-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: true
+
+jobs:
+  create-pr:
+    name: Create annual letter PR
+    if: >
+      github.event_name == 'workflow_dispatch'
+      || (
+        github.event.issue.pull_request == null
+        && startsWith(github.event.comment.body, '/annual-letter create-pr')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: 📥 Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: 🔎 Resolve issue payload
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            gh issue view "$ISSUE_NUMBER" --json body,number,title > annual-letter-issue.json
+            echo "ANNUAL_LETTER_ISSUE_PATH=annual-letter-issue.json" >> "$GITHUB_ENV"
+          else
+            echo "ANNUAL_LETTER_ISSUE_PATH=$GITHUB_EVENT_PATH" >> "$GITHUB_ENV"
+          fi
+
+      - name: 📝 Generate annual letter changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/annual-letter-from-issue.mjs
+
+      - name: 🔎 Show generated changes
+        run: git diff --stat
+
+      - name: 🌿 Commit and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: |
+          if git diff --quiet; then
+            gh issue comment "$ISSUE_NUMBER" --body "Annual letter automation found no changes to commit."
+            exit 0
+          fi
+
+          year="$(node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync('.annual-letter-generated.json','utf8')); console.log(pkg.year)")"
+          branch="annual-letter/${year}-issue-${ISSUE_NUMBER}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --heads origin "$branch" > /dev/null; then
+            git fetch origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+          fi
+          git checkout -B "$branch"
+          rm .annual-letter-generated.json
+          git add public/letters src/lib/annual-letters.ts
+          git commit -m "feat(letters): add ${year} annual letter"
+          git push --force-with-lease origin "$branch"
+
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          ## Summary
+
+          Adds the ${year} DTR annual letter submitted in #${ISSUE_NUMBER}.
+
+          ## Key Changes
+
+          - Adds \`public/letters/${year}-dtr-letter.pdf\`.
+          - Adds the annual letter metadata and table of contents to \`src/lib/annual-letters.ts\`.
+          - The letters page and home page media banner both read from \`annualLetters\`, so they update from the same source of truth.
+
+          ## Testing
+
+          - Not run by this automation. The normal PR checks will run after the PR opens.
+
+          ## Notes
+
+          Please review the uploaded PDF and table of contents page numbers before merging.
+          EOF
+
+          pr_url="$(gh pr list --head "$branch" --state open --json url --jq '.[0].url')"
+          if [ -z "$pr_url" ]; then
+            pr_url="$(gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "feat(letters): add ${year} annual letter" \
+              --body-file "$body_file")"
+          fi
+
+          gh issue comment "$ISSUE_NUMBER" --body "Annual letter PR created: ${pr_url}"

--- a/scripts/annual-letter-from-issue.mjs
+++ b/scripts/annual-letter-from-issue.mjs
@@ -1,0 +1,275 @@
+import { Buffer } from 'node:buffer'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+
+const ISSUE_PATH = process.env.ANNUAL_LETTER_ISSUE_PATH ?? process.env.GITHUB_EVENT_PATH
+const TOKEN = process.env.GITHUB_TOKEN
+const LETTERS_FILE = 'src/lib/annual-letters.ts'
+const GENERATED_SUMMARY_FILE = '.annual-letter-generated.json'
+
+function fail(message) {
+  throw new Error(`[annual-letter] ${message}`)
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function getIssueField(body, label) {
+  const pattern = new RegExp(
+    `(?:^|\\n)###\\s+${escapeRegExp(label)}\\s*\\n+([\\s\\S]*?)(?=\\n###\\s+|$)`,
+  )
+  const match = body.match(pattern)
+  const value = match?.[1]?.trim()
+
+  if (value === undefined || value === '' || value === '_No response_') {
+    return undefined
+  }
+
+  return value
+}
+
+function parseYear(value) {
+  if (value === undefined || !/^\d{4}$/.test(value)) {
+    fail('Annual letter year must be a four-digit year.')
+  }
+
+  return Number.parseInt(value, 10)
+}
+
+function parsePublicationDate(value) {
+  if (value === undefined) {
+    fail('Publication date is required.')
+  }
+
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (match === null) {
+    fail('Publication date must use YYYY-MM-DD.')
+  }
+
+  const [, year, month, day] = match
+  const parsed = {
+    day: Number.parseInt(day, 10),
+    month: Number.parseInt(month, 10),
+    year: Number.parseInt(year, 10),
+  }
+
+  const date = new Date(Date.UTC(parsed.year, parsed.month - 1, parsed.day))
+  if (
+    date.getUTCFullYear() !== parsed.year
+    || date.getUTCMonth() !== parsed.month - 1
+    || date.getUTCDate() !== parsed.day
+  ) {
+    fail('Publication date is not a valid calendar date.')
+  }
+
+  return parsed
+}
+
+function parsePdfUrl(value) {
+  if (value === undefined) {
+    fail('PDF upload or URL is required.')
+  }
+
+  const markdownUrls = [...value.matchAll(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g)]
+    .map(match => ({
+      label: match[1],
+      url: match[2],
+    }))
+  const rawUrls = [...value.matchAll(/https?:\/\/[^\s)]+/g)]
+    .map(match => ({
+      label: '',
+      url: match[0],
+    }))
+  const candidates = [...markdownUrls, ...rawUrls]
+  const pdf = candidates.find(({ label, url }) => {
+    try {
+      const parsed = new URL(url)
+      return parsed.protocol === 'https:'
+        && (
+          parsed.pathname.toLowerCase().includes('.pdf')
+          || label.toLowerCase().includes('.pdf')
+        )
+    }
+    catch {
+      return false
+    }
+  })
+
+  if (pdf === undefined) {
+    fail('PDF field must include an HTTPS PDF URL or a markdown link with a .pdf filename.')
+  }
+
+  return pdf.url
+}
+
+function parseTableOfContents(value) {
+  if (value === undefined) {
+    fail('Table of contents is required.')
+  }
+
+  const sections = value
+    .split('\n')
+    .map(line => line.trim().replace(/^[-*]\s+/, ''))
+    .filter(Boolean)
+    .map((line) => {
+      const separator = line.lastIndexOf('|')
+      if (separator === -1) {
+        fail(`Invalid table of contents line "${line}". Use "section name | page".`)
+      }
+
+      const name = line.slice(0, separator).trim()
+      const page = line.slice(separator + 1).trim()
+
+      if (name === '' || page === '') {
+        fail(`Invalid table of contents line "${line}". Section name and page are required.`)
+      }
+
+      if (!/^\d+[a-z]?$/i.test(page)) {
+        fail(`Invalid page "${page}" for section "${name}".`)
+      }
+
+      return { name, page }
+    })
+
+  if (sections.length === 0) {
+    fail('Table of contents must include at least one section.')
+  }
+
+  return sections
+}
+
+function tsString(value) {
+  return `'${value
+    .replaceAll('\\', '\\\\')
+    // Issue form textareas may include line breaks; keep generated TypeScript single-line-safe.
+    .replaceAll('\r', '\\r')
+    .replaceAll('\n', '\\n')
+    .replaceAll('\'', '\\\'')}'`
+}
+
+function renderAnnualLetterEntry({
+  date,
+  description,
+  link,
+  tableOfContents,
+  year,
+}) {
+  const toc = tableOfContents
+    .map(section => `      { name: ${tsString(section.name)}, page: ${tsString(section.page)} },`)
+    .join('\n')
+
+  return `  {
+    name: 'Annual Letter ${year}',
+    datePublished: new Date(${date.year}, ${date.month} - 1, ${date.day}), // year, month index (0-indexed), day
+    description: ${tsString(description ?? '')},
+    link: ${tsString(link)},
+    tableOfContents: [
+${toc}
+    ],
+  },
+`
+}
+
+function insertAnnualLetter(source, entry, year) {
+  const entryMatches = [...source.matchAll(/\n {2}\{\n {4}name: 'Annual Letter (\d{4})'/g)]
+  if (entryMatches.length === 0) {
+    fail(`Could not find existing annual letter entries in ${LETTERS_FILE}.`)
+  }
+
+  const duplicate = entryMatches.find(match => Number.parseInt(match[1], 10) === year)
+  if (duplicate !== undefined) {
+    fail(`Annual Letter ${year} already exists in ${LETTERS_FILE}.`)
+  }
+
+  const insertBefore = entryMatches.find(match => Number.parseInt(match[1], 10) < year)
+  if (insertBefore !== undefined) {
+    return `${source.slice(0, insertBefore.index + 1)}${entry}${source.slice(insertBefore.index + 1)}`
+  }
+
+  const closingIndex = source.lastIndexOf('\n]\n\nexport default annualLetters')
+  if (closingIndex === -1) {
+    fail(`Could not find annualLetters closing bracket in ${LETTERS_FILE}.`)
+  }
+
+  return `${source.slice(0, closingIndex + 1)}${entry}${source.slice(closingIndex + 1)}`
+}
+
+async function downloadPdf(url, targetPath) {
+  const headers = {}
+  const parsed = new URL(url)
+
+  if (TOKEN !== undefined && parsed.hostname === 'github.com') {
+    headers.Authorization = `Bearer ${TOKEN}`
+  }
+
+  const response = await fetch(url, {
+    headers,
+    redirect: 'follow',
+  })
+
+  if (!response.ok) {
+    fail(`Could not download PDF: ${response.status} ${response.statusText}.`)
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer())
+  if (!bytes.subarray(0, 5).equals(Buffer.from('%PDF-'))) {
+    fail('Downloaded file does not look like a PDF.')
+  }
+
+  await fs.mkdir(path.dirname(targetPath), { recursive: true })
+  await fs.writeFile(targetPath, bytes)
+}
+
+async function main() {
+  if (ISSUE_PATH === undefined) {
+    fail('ANNUAL_LETTER_ISSUE_PATH or GITHUB_EVENT_PATH is required.')
+  }
+
+  const event = JSON.parse(await fs.readFile(ISSUE_PATH, 'utf8'))
+  const issue = event.issue ?? event
+  if (issue?.body === undefined) {
+    fail('Issue body is missing from the GitHub event.')
+  }
+
+  const year = parseYear(getIssueField(issue.body, 'Annual letter year'))
+  const date = parsePublicationDate(getIssueField(issue.body, 'Publication date'))
+  if (date.year !== year) {
+    fail('Publication date year must match the annual letter year.')
+  }
+
+  const description = getIssueField(issue.body, 'Description') ?? ''
+  const pdfUrl = parsePdfUrl(getIssueField(issue.body, 'PDF upload or URL'))
+  const tableOfContents = parseTableOfContents(getIssueField(issue.body, 'Table of contents'))
+  const link = `/letters/${year}-dtr-letter.pdf`
+  const pdfPath = `public${link}`
+
+  await downloadPdf(pdfUrl, pdfPath)
+
+  const source = await fs.readFile(LETTERS_FILE, 'utf8')
+  const nextSource = insertAnnualLetter(
+    source,
+    renderAnnualLetterEntry({
+      date,
+      description,
+      link,
+      tableOfContents,
+      year,
+    }),
+    year,
+  )
+  await fs.writeFile(LETTERS_FILE, nextSource)
+  await fs.writeFile(
+    GENERATED_SUMMARY_FILE,
+    `${JSON.stringify({
+      issue: issue.number,
+      link,
+      pdfPath,
+      tableOfContentsCount: tableOfContents.length,
+      year,
+    }, null, 2)}\n`,
+  )
+}
+
+await main()

--- a/scripts/annual-letter-from-issue.ts
+++ b/scripts/annual-letter-from-issue.ts
@@ -8,15 +8,40 @@ const TOKEN = process.env.GITHUB_TOKEN
 const LETTERS_FILE = 'src/lib/annual-letters.ts'
 const GENERATED_SUMMARY_FILE = '.annual-letter-generated.json'
 
-function fail(message) {
+interface IssuePayload {
+  body?: string
+  issue?: IssuePayload
+  number?: number
+}
+
+interface DateParts {
+  day: number
+  month: number
+  year: number
+}
+
+interface TableOfContentsSection {
+  name: string
+  page: string
+}
+
+interface AnnualLetterEntryInput {
+  date: DateParts
+  description?: string
+  link: string
+  tableOfContents: TableOfContentsSection[]
+  year: number
+}
+
+function fail(message: string): never {
   throw new Error(`[annual-letter] ${message}`)
 }
 
-function escapeRegExp(value) {
+function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-function getIssueField(body, label) {
+function getIssueField(body: string, label: string): string | undefined {
   const pattern = new RegExp(
     `(?:^|\\n)###\\s+${escapeRegExp(label)}\\s*\\n+([\\s\\S]*?)(?=\\n###\\s+|$)`,
   )
@@ -30,7 +55,7 @@ function getIssueField(body, label) {
   return value
 }
 
-function parseYear(value) {
+function parseYear(value: string | undefined): number {
   if (value === undefined || !/^\d{4}$/.test(value)) {
     fail('Annual letter year must be a four-digit year.')
   }
@@ -38,7 +63,7 @@ function parseYear(value) {
   return Number.parseInt(value, 10)
 }
 
-function parsePublicationDate(value) {
+function parsePublicationDate(value: string | undefined): DateParts {
   if (value === undefined) {
     fail('Publication date is required.')
   }
@@ -67,7 +92,7 @@ function parsePublicationDate(value) {
   return parsed
 }
 
-function parsePdfUrl(value) {
+function parsePdfUrl(value: string | undefined): string {
   if (value === undefined) {
     fail('PDF upload or URL is required.')
   }
@@ -104,7 +129,7 @@ function parsePdfUrl(value) {
   return pdf.url
 }
 
-function parseTableOfContents(value) {
+function parseTableOfContents(value: string | undefined): TableOfContentsSection[] {
   if (value === undefined) {
     fail('Table of contents is required.')
   }
@@ -140,7 +165,7 @@ function parseTableOfContents(value) {
   return sections
 }
 
-function tsString(value) {
+function tsString(value: string): string {
   return `'${value
     .replaceAll('\\', '\\\\')
     // Issue form textareas may include line breaks; keep generated TypeScript single-line-safe.
@@ -155,7 +180,7 @@ function renderAnnualLetterEntry({
   link,
   tableOfContents,
   year,
-}) {
+}: AnnualLetterEntryInput): string {
   const toc = tableOfContents
     .map(section => `      { name: ${tsString(section.name)}, page: ${tsString(section.page)} },`)
     .join('\n')
@@ -172,7 +197,7 @@ ${toc}
 `
 }
 
-function insertAnnualLetter(source, entry, year) {
+function insertAnnualLetter(source: string, entry: string, year: number): string {
   const entryMatches = [...source.matchAll(/\n {2}\{\n {4}name: 'Annual Letter (\d{4})'/g)]
   if (entryMatches.length === 0) {
     fail(`Could not find existing annual letter entries in ${LETTERS_FILE}.`)
@@ -196,8 +221,8 @@ function insertAnnualLetter(source, entry, year) {
   return `${source.slice(0, closingIndex + 1)}${entry}${source.slice(closingIndex + 1)}`
 }
 
-async function downloadPdf(url, targetPath) {
-  const headers = {}
+async function downloadPdf(url: string, targetPath: string): Promise<void> {
+  const headers: Record<string, string> = {}
   const parsed = new URL(url)
 
   if (TOKEN !== undefined && parsed.hostname === 'github.com') {
@@ -227,7 +252,7 @@ async function main() {
     fail('ANNUAL_LETTER_ISSUE_PATH or GITHUB_EVENT_PATH is required.')
   }
 
-  const event = JSON.parse(await fs.readFile(ISSUE_PATH, 'utf8'))
+  const event = JSON.parse(await fs.readFile(ISSUE_PATH, 'utf8')) as IssuePayload
   const issue = event.issue ?? event
   if (issue?.body === undefined) {
     fail('Issue body is missing from the GitHub event.')


### PR DESCRIPTION
## 📌 Description

Automates the annual letter submission flow. A maintainer can create an Annual Letter issue with the PDF and table of contents, and the workflow automatically opens or updates a review PR that changes `public/letters/` and `src/lib/annual-letters.ts`.

## 🔍 Feature Changes

- [x] Other: Adds a structured Annual Letter issue template using the existing `content-updating` label.
- [x] Other: Adds a GitHub Actions workflow that runs on maintainer-created or maintainer-edited Annual Letter issues, with manual dispatch still available by issue number.
- [x] Other: Uses Node 24 to run the TypeScript generation script directly.
- [x] Other: Adds a generation script that validates issue fields, downloads and verifies the PDF, and inserts metadata in descending year order.

## ✅ Checklist

- [x] Code follows project coding style.
- [x] Relevant documentation is updated through the issue template and generated PR notes.
- [x] No dependency changes.

## 💬 Additional Notes

- GitHub issue templates cannot prevent non-maintainers from opening issues by themselves; the workflow enforces the automation boundary by requiring `OWNER`, `MEMBER`, or `COLLABORATOR` author association before it creates or updates a PR.
- The letters page already maps `annualLetters`, and the home media banner already derives the latest annual letter from the same array, so homepage updates are covered once the metadata entry is added.
- The workflow intentionally opens a normal review PR instead of pushing directly to `main`; reviewers should still confirm the uploaded PDF and table-of-contents page numbers.
- First real GitHub issue attachment should be observed after merge to confirm GitHub attachment URLs behave as expected in Actions.

## Testing

- `actionlint .github/workflows/annual-letter-issue.yml`
- `node --check scripts/annual-letter-from-issue.ts`
- `pnpm run lint:ci`
- `pnpm run typecheck`
- `pnpm run build`
- Node 24 `.ts` runtime smoke test, including GitHub attachment-style markdown link and multiline description escaping.
- Mismatched annual-letter/publication-year validation smoke test.