### PR TITLE
chore(deps): update pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dtr-web",
   "version": "2.0.0",
   "private": true,
-  "packageManager": "pnpm@11.5.0",
+  "packageManager": "pnpm@11.5.1",
   "homepage": "https://github.com/NUDelta/dtr-web",
   "engines": {
     "node": ">=22.x"


### PR DESCRIPTION
### Description

Weekly dependency update for ISO week 23 of 2026.

This PR updates the repo package manager pin from `pnpm@11.5.0` to `pnpm@11.5.1`.

### Dependency Updates

| Dependency Name | Old Version | New Version | Reason |
| --------------- | ----------- | ----------- | ------ |
| pnpm | 11.5.0 | 11.5.1 | Latest stable patch release reported by Corepack/pnpm |

### Deferred Updates

- `@eslint-react/eslint-plugin`: attempted patch update, but npm registry metadata/resolution was inconsistent while registry DNS was failing. No lockfile-safe update was kept.
- `@types/node` 24 -> 25: deferred because the repo targets Node `>=22.x`, and runtime-matched types should stay within the current compatible major unless the runtime is intentionally upgraded.

### Validation

- `pnpm install` passed.
- No generation/typegen script exists in `package.json`.
- `pnpm lint:fix` passed.
- `pnpm typecheck` passed.
- `pnpm build` did not complete locally because Next could not fetch Google Fonts `Lato` from `fonts.googleapis.com` in the local network environment.
- No `test` script exists.

### Notes

No codemods or migrations were required.
